### PR TITLE
Decouple service unavailability from 'queue full' 503 errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add `Error::Unavailable` to decouple service unavailability from 'queue full' 503 responses.
+
 ## 0.7.1
 
 * Add `Client::tokenize` and `Client::detokenize`. Thanks to @andreaskoepf


### PR DESCRIPTION
We have a use-case where the API client needs to differentiate 'busy' from 'unavailable'. This PR implements this with the following changes:

- Add Error::Unavailable and integrate with HTTP error handler
- Update test case for Error::Busy
- Add test case for Error::Unavailable