### PR TITLE
feat!: rename start_with to complete_with

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -48,14 +48,13 @@ pub struct Sampling<'a> {
     /// the smallest possible set of tokens whose cumulative probability exceeds the probability
     /// top_p. Set to 0 to get the same behaviour as `None`.
     pub top_p: Option<f64>,
-    /// Only start the completion with one of the following strings. The model will sample
-    /// between these options, and ignore anything else. Once one of the options is generated,
-    /// then the model will continue sampling until one of the stop reasons is reached.
+    /// Only complete with one of the following strings. The model will sample
+    /// between these options, and ignore anything else.
     ///
     /// For example, if trying to get the model to answer "Yes" or "No", and your prompt was
     /// "Can this question be answered?" this could be set to `[" Yes", " No"]`. Note the
     /// space in front of each option, since the model would start with a space character.
-    pub start_with_one_of: &'a [&'a str],
+    pub complete_with_one_of: &'a [&'a str],
 }
 
 impl Sampling<'_> {
@@ -65,7 +64,7 @@ impl Sampling<'_> {
         temperature: None,
         top_k: None,
         top_p: None,
-        start_with_one_of: &[],
+        complete_with_one_of: &[],
     };
 }
 
@@ -157,7 +156,7 @@ impl<'a> BodyCompletion<'a> {
             temperature: task.sampling.temperature,
             top_k: task.sampling.top_k,
             top_p: task.sampling.top_p,
-            completion_bias_inclusion: task.sampling.start_with_one_of,
+            completion_bias_inclusion: task.sampling.complete_with_one_of,
             stream: false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ impl Client {
         self.output_of(&task.with_model(model), how).await
     }
 
-    /// Execute any task with the aleph alpha API and fetch its result. This is most usefull in
+    /// Execute any task with the aleph alpha API and fetch its result. This is most useful in
     /// generic code then you want to execute arbitrary task types. Otherwise prefer methods taking
     /// concrete tasks like [`Self::completion`] for improved readability.
     pub async fn output_of<T: Job>(&self, task: &T, how: &How) -> Result<T::Output, Error> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -415,7 +415,7 @@ async fn only_answer_with_specific_animal() {
         prompt,
         stopping: Stopping::from_maximum_tokens(1),
         sampling: Sampling {
-            start_with_one_of: &[" dog"],
+            complete_with_one_of: &[" dog"],
             ..Default::default()
         },
     };
@@ -431,7 +431,6 @@ async fn only_answer_with_specific_animal() {
     assert_eq!(response.completion, " dog");
 }
 
-#[should_panic]
 #[tokio::test]
 async fn answer_should_continue() {
     // Given
@@ -442,7 +441,7 @@ async fn answer_should_continue() {
         prompt,
         stopping: Stopping::from_maximum_tokens(20),
         sampling: Sampling {
-            start_with_one_of: &[" Says.", " Art.", " Weekend."],
+            complete_with_one_of: &[" Says.", " Art.", " Weekend."],
             ..Default::default()
         },
     };
@@ -454,9 +453,7 @@ async fn answer_should_continue() {
         .unwrap();
 
     // Then
-    eprintln!("{}", response.completion);
-    assert!(response.completion.starts_with(" Says."));
-    assert!(response.completion.len() > " Says.".len());
+    assert_eq!(response.completion, " Says.");
 }
 
 #[tokio::test]


### PR DESCRIPTION
inference only returns one of these string, whereas the naming suggested it would return a completion starting with one of the string