### PR TITLE
chat sampling params

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -105,6 +105,8 @@ struct ChatBody<'a> {
     /// When no value is provided, the default value of 1 will be used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f64>,
     /// Whether to stream the response or not.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stream: bool,
@@ -118,6 +120,7 @@ impl<'a> ChatBody<'a> {
             max_tokens: task.maximum_tokens,
             temperature: task.sampling.temperature,
             top_p: task.sampling.top_p,
+            frequency_penalty: task.sampling.frequency_penalty,
             stream: false,
         }
     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{StreamTask, Task};
+use crate::{Sampling, StreamTask, Task};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Message<'a> {
@@ -39,14 +39,7 @@ pub struct TaskChat<'a> {
     /// The model will generate tokens until it generates one of the specified stop_sequences or it
     /// reaches its technical limit, which usually is its context window.
     pub maximum_tokens: Option<u32>,
-    /// A temperature encourages the model to produce less probable outputs ("be more creative").
-    /// Values are expected to be between 0 and 1. Try high values for a more random ("creative")
-    /// response.
-    pub temperature: Option<f64>,
-    /// Introduces random sampling for generated tokens by randomly selecting the next token from
-    /// the smallest possible set of tokens whose cumulative probability exceeds the probability
-    /// top_p. Set to 0 to get the same behaviour as `None`.
-    pub top_p: Option<f64>,
+    pub sampling: Sampling,
 }
 
 impl<'a> TaskChat<'a> {
@@ -56,8 +49,7 @@ impl<'a> TaskChat<'a> {
         TaskChat {
             messages: vec![message],
             maximum_tokens: None,
-            temperature: None,
-            top_p: None,
+            sampling: Sampling::default(),
         }
     }
 
@@ -67,8 +59,7 @@ impl<'a> TaskChat<'a> {
         TaskChat {
             messages,
             maximum_tokens: None,
-            temperature: None,
-            top_p: None,
+            sampling: Sampling::default(),
         }
     }
 
@@ -81,18 +72,6 @@ impl<'a> TaskChat<'a> {
     /// Sets the maximum token attribute of this TaskChat.
     pub fn with_maximum_tokens(mut self, maximum_tokens: u32) -> Self {
         self.maximum_tokens = Some(maximum_tokens);
-        self
-    }
-
-    /// Sets the temperature attribute of this TaskChat.
-    pub fn with_temperature(mut self, temperature: f64) -> Self {
-        self.temperature = Some(temperature);
-        self
-    }
-
-    /// Sets the top_p attribute of this TaskChat.
-    pub fn with_top_p(mut self, top_p: f64) -> Self {
-        self.top_p = Some(top_p);
         self
     }
 }
@@ -137,8 +116,8 @@ impl<'a> ChatBody<'a> {
             model,
             messages: &task.messages,
             maximum_tokens: task.maximum_tokens,
-            temperature: task.temperature,
-            top_p: task.top_p,
+            temperature: task.sampling.temperature,
+            top_p: task.sampling.top_p,
             stream: false,
         }
     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -107,6 +107,8 @@ struct ChatBody<'a> {
     pub top_p: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub frequency_penalty: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f64>,
     /// Whether to stream the response or not.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub stream: bool,
@@ -121,6 +123,7 @@ impl<'a> ChatBody<'a> {
             temperature: task.sampling.temperature,
             top_p: task.sampling.top_p,
             frequency_penalty: task.sampling.frequency_penalty,
+            presence_penalty: task.sampling.presence_penalty,
             stream: false,
         }
     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -33,6 +33,7 @@ pub struct TaskChat<'a> {
     pub messages: Vec<Message<'a>>,
     /// Controls in which circumstances the model will stop generating new tokens.
     pub stopping: Stopping<'a>,
+    /// Sampling controls how the tokens ("words") are selected for the completion.
     pub sampling: Sampling,
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -95,7 +95,7 @@ struct ChatBody<'a> {
     messages: &'a [Message<'a>],
     /// Limits the number of tokens, which are generated for the completion.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maximum_tokens: Option<u32>,
+    pub max_tokens: Option<u32>,
     /// Controls the randomness of the model. Lower values will make the model more deterministic and higher values will make it more random.
     /// Mathematically, the temperature is used to divide the logits before sampling. A temperature of 0 will always return the most likely token.
     /// When no value is provided, the default value of 1 will be used.
@@ -115,7 +115,7 @@ impl<'a> ChatBody<'a> {
         Self {
             model,
             messages: &task.messages,
-            maximum_tokens: task.maximum_tokens,
+            max_tokens: task.maximum_tokens,
             temperature: task.sampling.temperature,
             top_p: task.sampling.top_p,
             stream: false,

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -112,7 +112,7 @@ pub struct Stopping<'a> {
     pub stop_sequences: &'a [&'a str],
 }
 
-impl Stopping<'_> {
+impl<'a> Stopping<'a> {
     /// Only stop once the model reaches its technical limit, usually the context window.
     pub const NO_TOKEN_LIMIT: Self = Stopping {
         maximum_tokens: None,
@@ -124,6 +124,13 @@ impl Stopping<'_> {
         Self {
             maximum_tokens: Some(maximum_tokens),
             stop_sequences: &[],
+        }
+    }
+
+    pub fn from_stop_sequences(stop_sequences: &'a [&'a str]) -> Self {
+        Self {
+            maximum_tokens: None,
+            stop_sequences,
         }
     }
 }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -62,6 +62,17 @@ pub struct Sampling {
     /// is mentioned in the completion, the more its probability will decrease.
     /// A negative value will increase the likelihood of repeating tokens.
     pub frequency_penalty: Option<f64>,
+    /// The presence penalty reduces the likelihood of generating tokens that are already present
+    /// in the generated text (repetition_penalties_include_completion=true) respectively the
+    /// prompt (repetition_penalties_include_prompt=true). Presence penalty is independent of the
+    /// number of occurrences. Increase the value to reduce the likelihood of repeating text.
+    /// An operation like the following is applied:
+    ///
+    /// logits[t] -> logits[t] - 1 * penalty
+    ///
+    /// where logits[t] is the logits for any given token. Note that the formula is independent
+    /// of the number of times that a token appears.
+    pub presence_penalty: Option<f64>,
 }
 
 impl Sampling {
@@ -72,6 +83,7 @@ impl Sampling {
         top_k: None,
         top_p: None,
         frequency_penalty: None,
+        presence_penalty: None,
     };
 }
 
@@ -158,6 +170,8 @@ struct BodyCompletion<'a> {
     pub raw_completion: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub frequency_penalty: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f64>,
 }
 
 impl<'a> BodyCompletion<'a> {
@@ -173,6 +187,7 @@ impl<'a> BodyCompletion<'a> {
             stream: false,
             raw_completion: task.special_tokens,
             frequency_penalty: task.sampling.frequency_penalty,
+            presence_penalty: task.sampling.presence_penalty,
         }
     }
     pub fn with_streaming(mut self) -> Self {

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -57,6 +57,11 @@ pub struct Sampling {
     /// the smallest possible set of tokens whose cumulative probability exceeds the probability
     /// top_p. Set to 0 to get the same behaviour as `None`.
     pub top_p: Option<f64>,
+    /// When specified, this number will decrease (or increase) the likelihood of repeating tokens
+    /// that were mentioned prior in the completion. The penalty is cumulative. The more a token
+    /// is mentioned in the completion, the more its probability will decrease.
+    /// A negative value will increase the likelihood of repeating tokens.
+    pub frequency_penalty: Option<f64>,
 }
 
 impl Sampling {
@@ -66,6 +71,7 @@ impl Sampling {
         temperature: None,
         top_k: None,
         top_p: None,
+        frequency_penalty: None,
     };
 }
 
@@ -150,6 +156,8 @@ struct BodyCompletion<'a> {
     /// Setting tokens to true or log_probs to any value will also trigger the raw completion to be returned.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub raw_completion: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f64>,
 }
 
 impl<'a> BodyCompletion<'a> {
@@ -164,6 +172,7 @@ impl<'a> BodyCompletion<'a> {
             top_p: task.sampling.top_p,
             stream: false,
             raw_completion: task.special_tokens,
+            frequency_penalty: task.sampling.frequency_penalty,
         }
     }
     pub fn with_streaming(mut self) -> Self {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -148,7 +148,7 @@ async fn must_panic_if_authentication_is_missing() {
 }
 
 #[tokio::test]
-async fn semanitc_search_with_luminous_base() {
+async fn semantic_search_with_luminous_base() {
     // Given
     let robot_fact = Prompt::from_text(
         "A robot is a machine—especially one programmable by a computer—capable of carrying out a \

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -618,7 +618,40 @@ async fn frequency_penalty_request() {
 
     // Then we get a response with the word "white" appearing more than 10 times
     assert!(!response.message.content.is_empty());
-    dbg!(&response.message.content);
+    let count = response
+        .message
+        .content
+        .to_lowercase()
+        .split_whitespace()
+        .filter(|word| *word == "oat")
+        .count();
+    assert!(count > 5);
+}
+
+#[tokio::test]
+async fn presence_penalty_request() {
+    // Given a high negative presence penalty
+    let model = "pharia-1-llm-7b-control";
+    let client = Client::with_auth(inference_url(), pharia_ai_token()).unwrap();
+    let message = Message::user("Haiku about oat milk!");
+    let sampling = Sampling {
+        presence_penalty: Some(-10.0),
+        ..Default::default()
+    };
+    let task = TaskChat {
+        messages: vec![message],
+        maximum_tokens: Some(20),
+        sampling,
+    };
+
+    // When the response is requested
+    let response = client
+        .output_of(&task.with_model(model), &How::default())
+        .await
+        .unwrap();
+
+    // Then we get a response with the word "white" appearing more than 10 times
+    assert!(!response.message.content.is_empty());
     let count = response
         .message
         .content

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -604,9 +604,10 @@ async fn frequency_penalty_request() {
         frequency_penalty: Some(-10.0),
         ..Default::default()
     };
+    let stopping = Stopping::from_maximum_tokens(20);
     let task = TaskChat {
         messages: vec![message],
-        maximum_tokens: Some(20),
+        stopping,
         sampling,
     };
 
@@ -638,9 +639,10 @@ async fn presence_penalty_request() {
         presence_penalty: Some(-10.0),
         ..Default::default()
     };
+    let stopping = Stopping::from_maximum_tokens(20);
     let task = TaskChat {
         messages: vec![message],
-        maximum_tokens: Some(20),
+        stopping,
         sampling,
     };
 
@@ -660,4 +662,32 @@ async fn presence_penalty_request() {
         .filter(|word| *word == "oat")
         .count();
     assert!(count > 5);
+}
+
+#[tokio::test]
+async fn stop_sequences_request() {
+    // Given a stop sequence
+    let model = "pharia-1-llm-7b-control";
+    let client = Client::with_auth(inference_url(), pharia_ai_token()).unwrap();
+    let message = Message::user("An apple a day");
+
+    let stopping = Stopping {
+        stop_sequences: &["doctor"],
+        maximum_tokens: None,
+    };
+    let task = TaskChat {
+        messages: vec![message],
+        stopping,
+        sampling: Sampling::MOST_LIKELY,
+    };
+
+    // When the response is requested
+    let response = client
+        .output_of(&task.with_model(model), &How::default())
+        .await
+        .unwrap();
+
+    // Then the finish reason is `content_filter`
+    // Actually, it should be `stop`, but the api scheduler is inconsistent here
+    assert_eq!(response.finish_reason, "content_filter");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -432,59 +432,6 @@ async fn describe_image_starting_from_a_dyn_image() {
 }
 
 #[tokio::test]
-async fn only_answer_with_specific_animal() {
-    // Given
-    let prompt = Prompt::from_text("What is your favorite animal?");
-
-    // When
-    let task = TaskCompletion {
-        prompt,
-        stopping: Stopping::from_maximum_tokens(1),
-        sampling: Sampling {
-            complete_with_one_of: &[" dog"],
-            ..Default::default()
-        },
-        special_tokens: false,
-    };
-    let model = "luminous-base";
-    let client = Client::with_auth(inference_url(), pharia_ai_token()).unwrap();
-    let response = client
-        .output_of(&task.with_model(model), &How::default())
-        .await
-        .unwrap();
-
-    // Then
-    eprintln!("{}", response.completion);
-    assert_eq!(response.completion, " dog");
-}
-
-#[tokio::test]
-async fn answer_should_continue() {
-    // Given
-    let prompt = Prompt::from_text("Knock knock. Who's there?");
-
-    // When
-    let task = TaskCompletion {
-        prompt,
-        stopping: Stopping::from_maximum_tokens(20),
-        sampling: Sampling {
-            complete_with_one_of: &[" Says.", " Art.", " Weekend."],
-            ..Default::default()
-        },
-        special_tokens: false,
-    };
-    let model = "luminous-base";
-    let client = Client::with_auth(inference_url(), pharia_ai_token()).unwrap();
-    let response = client
-        .output_of(&task.with_model(model), &How::default())
-        .await
-        .unwrap();
-
-    // Then
-    assert_eq!(response.completion, " Says.");
-}
-
-#[tokio::test]
 async fn batch_semanitc_embed_with_luminous_base() {
     // Given
     let robot_fact = Prompt::from_text(


### PR DESCRIPTION
- **feat!: remove support for complete_with_one_of sampling param**
- **refactor: use completion sampling params for chat task**
- **test: fix typo**
- **fix: serialize maximum tokens as max_tokens**
- **feat: support frequency penalty for completions**
- **feat: support presence penalty for completions**
