### PR TITLE
feat: add instructable embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ fn main() {
     // Authenticate against API. Fetches token.
     let client = Client::from_env().unwrap();
 
-    // Name of the model we we want to use. Large models give usually better answer, but are also
+    // Name of the model we want to use. Large models give usually better answers, but are also
     // more costly.
     let model = "luminous-base";
 
     // The task we want to perform. Here we want to continue the sentence: "An apple a day ..."
     let task = TaskCompletion::from_text("An apple a day").with_maximum_tokens(20);
-    
+
     // Retrieve the answer from the API
     let response = client.completion(&task, model, &How::default()).await.unwrap();
 
@@ -27,4 +27,5 @@ fn main() {
 }
 ```
 
-This is a **work in progress** currently the Rust client is not a priority on our Roadmap, so expect this client to be incomplete. If we work on it expect interfaces to break.
+This is a **work in progress** currently the Rust client is not a priority on our Roadmap, so expect this client to be
+incomplete. If we work on it expect interfaces to break.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub use self::{
     prompt::{Modality, Prompt},
     semantic_embedding::{
         SemanticRepresentation, TaskBatchSemanticEmbedding, TaskSemanticEmbedding,
+        TaskSemanticEmbeddingWithInstruction,
     },
     stream::{StreamJob, StreamTask},
     tokenization::{TaskTokenization, TokenizationOutput},
@@ -157,6 +158,18 @@ impl Client {
         self.http_client.output_of(task, how).await
     }
 
+    /// An embedding trying to capture the semantic meaning of a text.
+    ///
+    /// By providing instructions, you can help the model better understand the nuances of your
+    /// specific data, leading to embeddings that are more useful for your use case.
+    pub async fn semantic_embedding_with_instruction(
+        &self,
+        task: &TaskSemanticEmbeddingWithInstruction<'_>,
+        how: &How,
+    ) -> Result<SemanticEmbeddingOutput, Error> {
+        self.http_client.output_of(task, how).await
+    }
+
     /// Instruct a model served by the aleph alpha API to continue writing a piece of text (or
     /// multimodal document).
     ///
@@ -228,7 +241,7 @@ impl Client {
         task: &'task TaskCompletion<'task>,
         model: &'task str,
         how: &How,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<CompletionEvent, Error>> + Send + 'task>>, Error>
+    ) -> Result<Pin<Box<dyn Stream<Item=Result<CompletionEvent, Error>> + Send + 'task>>, Error>
     {
         self.http_client
             .stream_output_of(StreamTask::with_model(task, model), how)
@@ -300,7 +313,7 @@ impl Client {
         task: &'task TaskChat<'_>,
         model: &'task str,
         how: &How,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<ChatEvent, Error>> + Send + 'task>>, Error> {
+    ) -> Result<Pin<Box<dyn Stream<Item=Result<ChatEvent, Error>> + Send + 'task>>, Error> {
         self.http_client
             .stream_output_of(StreamTask::with_model(task, model), how)
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!     // Authenticate against API. Fetches token.
 //!     let client = Client::from_env().unwrap();
 //!
-//!     // Name of the model we we want to use. Large models give usually better answer, but are also
+//!     // Name of the model we want to use. Large models give usually better answer, but are also
 //!     // more costly.
 //!     let model = "luminous-base";
 //!
@@ -103,7 +103,7 @@ impl Client {
     ///     // Authenticate against API. Fetches token.
     ///     let client = Client::from_env()?;
     ///
-    ///     // Name of the model we we want to use. Large models give usually better answer, but are
+    ///     // Name of the model we want to use. Large models give usually better answer, but are
     ///     // also slower and more costly.
     ///     let model = "luminous-base";
     ///
@@ -137,7 +137,7 @@ impl Client {
     }
 
     /// An embedding trying to capture the semantic meaning of a text. Cosine similarity can be used
-    /// find out how well two texts (or multimodal prompts) match. Useful for search usecases.
+    /// find out how well two texts (or multimodal prompts) match. Useful for search use cases.
     ///
     /// See the example for [`cosine_similarity`].
     pub async fn semantic_embedding(
@@ -148,7 +148,7 @@ impl Client {
         self.http_client.output_of(task, how).await
     }
 
-    /// An batch of embeddings trying to capture the semantic meaning of a text.
+    /// A batch of embeddings trying to capture the semantic meaning of a text.
     pub async fn batch_semantic_embedding(
         &self,
         task: &TaskBatchSemanticEmbedding<'_>,

--- a/src/semantic_embedding.rs
+++ b/src/semantic_embedding.rs
@@ -105,7 +105,7 @@ pub struct TaskBatchSemanticEmbedding<'a> {
     /// The prompt (usually text) to be embedded.
     pub prompts: Vec<Prompt<'a>>,
     /// Semantic representation to embed the prompt with. This parameter is governed by the specific
-    /// usecase in mind.
+    /// use case in mind.
     pub representation: SemanticRepresentation,
     /// Default behaviour is to return the full embedding, but you can optionally request an
     /// embedding compressed to a smaller set of dimensions. A size of `128` is supported for every

--- a/src/semantic_embedding.rs
+++ b/src/semantic_embedding.rs
@@ -3,7 +3,10 @@ use std::fmt::Debug;
 
 use crate::{http::Task, Job, Prompt};
 
-/// Allows you to choose a semantic representation fitting for your usecase.
+const DEFAULT_EMBEDDING_MODEL: &str = "luminous-base";
+const DEFAULT_EMBEDDING_MODEL_WITH_INSTRUCTION: &str = "pharia-1-embedding-4608-control";
+
+/// Allows you to choose a semantic representation fitting for your use case.
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum SemanticRepresentation {
@@ -86,9 +89,8 @@ impl Job for TaskSemanticEmbedding<'_> {
     type ResponseBody = SemanticEmbeddingOutput;
 
     fn build_request(&self, client: &reqwest::Client, base: &str) -> reqwest::RequestBuilder {
-        let model = "luminous-base";
         let body = RequestBody {
-            model,
+            model: DEFAULT_EMBEDDING_MODEL,
             semantic_embedding_task: self,
         };
         client.post(format!("{base}/semantic_embed")).json(&body)
@@ -131,13 +133,77 @@ impl Job for TaskBatchSemanticEmbedding<'_> {
     type ResponseBody = BatchSemanticEmbeddingOutput;
 
     fn build_request(&self, client: &reqwest::Client, base: &str) -> reqwest::RequestBuilder {
-        let model = "luminous-base";
+        let body = RequestBody {
+            model: DEFAULT_EMBEDDING_MODEL,
+            semantic_embedding_task: self,
+        };
+        client
+            .post(format!("{base}/batch_semantic_embed"))
+            .json(&body)
+    }
+
+    fn body_to_output(&self, response: Self::ResponseBody) -> Self::Output {
+        response
+    }
+}
+
+/// Allows you to choose a semantic representation fitting for your use case.
+///
+/// By providing instructions, you can help the model better understand the nuances of your specific
+/// data, leading to embeddings that are more useful for your use case.
+#[derive(Serialize, Debug)]
+pub struct TaskSemanticEmbeddingWithInstruction<'a> {
+    /// To further improve performance by steering the model, you can use instructions.
+    ///
+    /// Instructions can help the model understand nuances of your specific data and ultimately lead
+    /// to embeddings that are more useful for your use-case. In this case, we aim to further
+    /// increase the absolute difference between the cosine similarities. Instruction can also be
+    /// the empty string.
+    pub instruction: &'a str,
+    /// The prompt (usually text) to be embedded.
+    #[serde(rename = "input")]
+    pub prompt: Prompt<'a>,
+    /// Return normalized embeddings. This can be used to save on additional compute when applying a
+    /// cosine similarity metric.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub normalize: Option<bool>,
+}
+
+impl Task for TaskSemanticEmbeddingWithInstruction<'_> {
+    type Output = SemanticEmbeddingOutput;
+    type ResponseBody = SemanticEmbeddingOutput;
+
+    fn build_request(
+        &self,
+        client: &reqwest::Client,
+        base: &str,
+        model: &str,
+    ) -> reqwest::RequestBuilder {
         let body = RequestBody {
             model,
             semantic_embedding_task: self,
         };
         client
-            .post(format!("{base}/batch_semantic_embed"))
+            .post(format!("{base}/instructable_embed"))
+            .json(&body)
+    }
+
+    fn body_to_output(&self, response: Self::ResponseBody) -> Self::Output {
+        response
+    }
+}
+
+impl Job for TaskSemanticEmbeddingWithInstruction<'_> {
+    type Output = SemanticEmbeddingOutput;
+    type ResponseBody = SemanticEmbeddingOutput;
+
+    fn build_request(&self, client: &reqwest::Client, base: &str) -> reqwest::RequestBuilder {
+        let body = RequestBody {
+            model: DEFAULT_EMBEDDING_MODEL_WITH_INSTRUCTION,
+            semantic_embedding_task: self,
+        };
+        client
+            .post(format!("{base}/instructable_embed"))
             .json(&body)
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -434,7 +434,7 @@ async fn describe_image_starting_from_a_dyn_image() {
 }
 
 #[tokio::test]
-async fn batch_semanitc_embed_with_luminous_base() {
+async fn batch_semantic_embed_with_luminous_base() {
     // Given
     let robot_fact = Prompt::from_text(
         "A robot is a machine—especially one programmable by a computer—capable of carrying out a \


### PR DESCRIPTION
Add functionality to create [semantic embeddings with instruction](https://docs.aleph-alpha.com/products/apis/pharia-inference/instructable-embed/).